### PR TITLE
chore(config): use XDG-compliant log path .local/state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,7 +175,7 @@ chmod +x transmission-done.sh install.sh run_tests.sh
 
 ```bash
 # Watch processing logs in real-time
-tail -f ~/.filebot/logs/transmission-processing.log
+tail -f ~/.local/state/transmission-processing.log
 
 # Inspect Transmission environment (add to script temporarily)
 env > /tmp/transmission-env.log
@@ -195,7 +195,7 @@ plex:
   token: abc123xyz                # Obtained during install.sh
   media_path: /path/to/plex/media # Target directory for organized media
 logging:
-  file: .filebot/logs/transmission-processing.log  # Relative to home
+  file: .local/state/transmission-processing.log  # Relative to home
   max_size: 10485760  # Bytes (10MB) - triggers log rotation
 ```
 

--- a/config.yml.template
+++ b/config.yml.template
@@ -7,5 +7,5 @@ plex:
   token: YOUR_PLEX_TOKEN      # Your Plex authentication token
   media_path: YOUR_PLEX_MEDIA_PATH  # Root path for media library
 logging:
-  file: .filebot/logs/transmission-processing.log  # Relative to home dir
+  file: .local/state/transmission-processing.log  # Relative to home dir
   max_size: 10485760  # Max log size in bytes (10MB)

--- a/install.sh
+++ b/install.sh
@@ -599,7 +599,7 @@ plex:
   token: ${plex_token}
   media_path: ${media_path}
 logging:
-  file: .filebot/logs/transmission-processing.log
+  file: .local/state/transmission-processing.log
   max_size: 10485760  # 10MB
 EOF
 


### PR DESCRIPTION
## Summary

- Changed log file location from `.filebot/logs/` to `.local/state/` for XDG compliance
- Updated install.sh, config.yml.template, and CLAUDE.md documentation
- Separates our logs from FileBot's internal data directory

## Motivation

The `.filebot/` directory should be reserved for FileBot's own internal data. Following the XDG Base Directory Specification, application state and log files should be stored in `~/.local/state/`.

## Changes

**install.sh**:
- Generate configs with `file: .local/state/transmission-processing.log`

**config.yml.template**:
- Updated example log path to `.local/state/transmission-processing.log`

**CLAUDE.md**:
- Updated debugging commands: `tail -f ~/.local/state/transmission-processing.log`
- Updated configuration file structure example

## Migration

Users will need to update their config on the server by either:
1. Re-running `./install.sh` to regenerate the config file
2. Manually editing `~/.config/transmission-done/config.yml` to change the log path

Old logs in `~/.filebot/logs/` can be safely deleted or kept for reference.

## Test Plan

- [x] All tests pass (110 tests)
- [x] Code review passed (code-reviewer agent)
- [x] ShellCheck clean
- [ ] User to update server config and verify logging works at new location

## Benefits

- XDG-compliant location for application state/logs
- Clear separation between our logs and FileBot's internal data
- More predictable location following Linux/Unix standards