### PR TITLE
fix(env): robust environment handling for Transmission execution

### DIFF
--- a/transmission-done.sh
+++ b/transmission-done.sh
@@ -3,10 +3,12 @@
 # Detect architecture and set Homebrew prefix BEFORE strict mode
 ARCH="$(arch)"
 case "${ARCH}" in
-  i386)
+  i386 | x86_64)
+    # Intel Macs (both old i386 and modern x86_64)
     export HOMEBREW_PREFIX="/usr/local"
     ;;
   arm64)
+    # Apple Silicon Macs
     export HOMEBREW_PREFIX="/opt/homebrew"
     ;;
   *)
@@ -46,8 +48,13 @@ if [[ "${SCRIPT_DIR}" =~ ^(/Users/[^/]+) ]]; then
 elif [[ "${SCRIPT_DIR}" =~ ^(/home/[^/]+) ]]; then
   DERIVED_HOME="${BASH_REMATCH[1]}"
 else
-  # Fallback to USER-based home
-  DERIVED_HOME="/Users/${USER}"
+  # Fallback: try USER variable, then whoami, then generic default
+  if [[ -n "${USER:-}" ]]; then
+    DERIVED_HOME="/Users/${USER}"
+  else
+    # Use whoami as final fallback (works even in minimal environments)
+    DERIVED_HOME="/Users/$(whoami)"
+  fi
 fi
 
 # Use HOME if set and valid, otherwise use derived value


### PR DESCRIPTION
## Summary

Fixes critical environment issues that prevented the script from running when invoked by Transmission.

## Root Cause

Transmission executes scripts with a minimal environment:
- **No HOME variable** - causes immediate exit with `set -u`
- **Limited PATH**: `/usr/bin:/bin:/usr/sbin:/sbin` - no Homebrew paths
- **No standard user environment** - can't rely on shell initialization

The script referenced `${HOME}` at line 20 before any logging was set up, causing immediate failure without any log output.

## Changes

### 1. HOME Derivation from Script Path
```bash
# Resolve symlinks to get real script location
SCRIPT_SOURCE="${BASH_SOURCE[0]}"
while [[ -L "${SCRIPT_SOURCE}" ]]; do
  # ... resolve symlinks ...
done

# Extract /Users/username or /home/username from path
if [[ "${SCRIPT_DIR}" =~ ^(/Users/[^/]+) ]]; then
  DERIVED_HOME="${BASH_REMATCH[1]}"
# ... with fallback to /Users/${USER}

EFFECTIVE_HOME="${HOME:-${DERIVED_HOME}}"
```

### 2. Architecture-Aware Homebrew Path Setup
```bash
ARCH="$(arch)"
case "${ARCH}" in
  i386) export HOMEBREW_PREFIX="/usr/local" ;;
  arm64) export HOMEBREW_PREFIX="/opt/homebrew" ;;
esac

PATH="/usr/bin:/bin:/usr/sbin:/sbin:${HOMEBREW_PREFIX}/bin:/usr/local/bin"
```

### 3. Full Dependency Paths
```bash
readonly YQ="${HOMEBREW_PREFIX}/bin/yq"
readonly FILEBOT="${HOMEBREW_PREFIX}/bin/filebot"
```

All `yq` and `filebot` calls updated to use these variables.

## Test Plan

- [x] All 110 tests pass (unit + integration)
- [x] Code review passed
- [x] ShellCheck clean
- [ ] Test on server: Deploy and trigger via Transmission
- [ ] Verify logging starts correctly
- [ ] Verify FileBot processing completes

## Related Issues

Fixes: "transmission isn't launching the symlinked script, or it's failing immediately and not logging anything"

Manual mode (.command script) worked because it runs in user's full shell environment with HOME set and proper PATH.